### PR TITLE
Update maven-release-plugin to fix scm issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 					<!-- WORKAROUND: https://issues.sonatype.org/browse/CENTRALSRV-35 -->
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.4.1</version>
+					<version>2.5.3</version>
 					<configuration>
 						<mavenExecutorId>forked-path</mavenExecutorId>
 						<useReleaseProfile>false</useReleaseProfile>


### PR DESCRIPTION
The newer version of the release plugin depends on a version of the Git SCM provider in which the issue described in the ticket below has been fixed.

https://issues.apache.org/jira/browse/SCM-740