### PR TITLE
Support for Solaris and AIX

### DIFF
--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -109,5 +109,17 @@
 				<cmake.classifier>mac64</cmake.classifier>
 			</properties>
 		</profile>
+		<profile>
+			<id>sunos</id>
+			<activation>
+				<os>
+					<name>sunos</name>
+				</os>
+			</activation>
+			<properties>
+				<download.cmake>false</download.cmake>
+				<cmake.classifier>sunos</cmake.classifier>
+			</properties>
+		</profile>
 	</profiles>
 </project>

--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -121,5 +121,17 @@
 				<cmake.classifier>sunos</cmake.classifier>
 			</properties>
 		</profile>
+		<profile>
+			<id>aix</id>
+			<activation>
+				<os>
+					<name>aix</name>
+				</os>
+			</activation>
+			<properties>
+				<download.cmake>false</download.cmake>
+				<cmake.classifier>aix</cmake.classifier>
+			</properties>
+		</profile>
 	</profiles>
 </project>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -277,5 +277,16 @@
 				<cmake.classifier>sunos</cmake.classifier>
 			</properties>
 		</profile>
+		<profile>
+			<id>aix</id>
+			<activation>
+				<os>
+					<name>aix</name>
+				</os>
+			</activation>
+			<properties>
+				<cmake.classifier>aix</cmake.classifier>
+			</properties>
+		</profile>
 	</profiles>
 </project>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -266,5 +266,16 @@
 				<cmake.classifier>mac64</cmake.classifier>
 			</properties>
 		</profile>
+		<profile>
+			<id>sunos</id>
+			<activation>
+				<os>
+					<name>sunos</name>
+				</os>
+			</activation>
+			<properties>
+				<cmake.classifier>sunos</cmake.classifier>
+			</properties>
+		</profile>
 	</profiles>
 </project>

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
@@ -140,6 +140,8 @@ public class GenerateMojo
 						else throw new MojoExecutionException("Unsupported Mac arch: " + arch);
 					else if (os.toLowerCase().startsWith("sunos"))
 							classifier = "sunos";
+					else if (os.toLowerCase().startsWith("aix"))
+							classifier = "aix";
 					else
 						throw new MojoExecutionException("Unsupported os.name: " + os);
 				}

--- a/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
+++ b/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
@@ -92,15 +92,17 @@ public abstract class CMakeMojoIntegrationTest
         String classifier = System.getProperty(CMAKE_CLASSIFIER);
 
         if (classifier.equals("linux64")) {
-            return "-Plinux64,-linux32,-windows,-mac64,-sunos";
+            return "-Plinux64,-linux32,-windows,-mac64,-sunos,-aix";
         } else if (classifier.equals("linux32")) {
-            return "-Plinux32,-linux64,-windows,-mac64,-sunos";
+            return "-Plinux32,-linux64,-windows,-mac64,-sunos,-aix";
         } else if (classifier.equals("windows")) {
-            return "-Pwindows,-linux32,-linux64,-mac64,-sunos";
+            return "-Pwindows,-linux32,-linux64,-mac64,-sunos,-aix";
         } else if (classifier.equals("mac64")) {
-            return "-Pmac64,-windows,-linux32,-linux64,-sunos";
+            return "-Pmac64,-windows,-linux32,-linux64,-sunos,-aix";
         } else if (classifier.equals("sunos")) {
-            return "-Psunos,-mac64,-windows,-linux32,-linux64";
+            return "-Psunos,-mac64,-windows,-linux32,-linux64,-aix";
+        } else if (classifier.equals("aix")) {
+            return "-Paix,-sunos,-mac64,-windows,-linux32,-linux64";
         } else {
             throw new VerificationException("Unexpected test profile: " + classifier);
         }

--- a/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
+++ b/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
@@ -71,6 +71,9 @@ public abstract class CMakeMojoIntegrationTest
         if (System.getProperty(DOWNLOAD_CMAKE, "true").equals("false")) {
             sysProperties.setProperty(DOWNLOAD_CMAKE, "false");
         }
+        if (System.getProperty("cmake.root.dir") != null) {
+            sysProperties.setProperty("cmake.root.dir", System.getProperty("cmake.root.dir"));
+        }
         // Set the profile that's being used in the running of the tests
         verifier.addCliOption(getActivatedProfile());
 
@@ -89,13 +92,15 @@ public abstract class CMakeMojoIntegrationTest
         String classifier = System.getProperty(CMAKE_CLASSIFIER);
 
         if (classifier.equals("linux64")) {
-            return "-Plinux64,-linux32,-windows,-mac64";
+            return "-Plinux64,-linux32,-windows,-mac64,-sunos";
         } else if (classifier.equals("linux32")) {
-            return "-Plinux32,-linux64,-windows,-mac64";
+            return "-Plinux32,-linux64,-windows,-mac64,-sunos";
         } else if (classifier.equals("windows")) {
-            return "-Pwindows,-linux32,-linux64,-mac64";
+            return "-Pwindows,-linux32,-linux64,-mac64,-sunos";
         } else if (classifier.equals("mac64")) {
-            return "-Pmac64,-windows,-linux32,-linux64";
+            return "-Pmac64,-windows,-linux32,-linux64,-sunos";
+        } else if (classifier.equals("sunos")) {
+            return "-Psunos,-mac64,-windows,-linux32,-linux64";
         } else {
             throw new VerificationException("Unexpected test profile: " + classifier);
         }

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/CMakeLists.txt
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.6.4)
-project(DashboardTest)
+project(DashboardTest LANGUAGES C)
 add_executable(dashboard-test main.c)
 
 # Turn on testing

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/main.c
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/main.c
@@ -2,5 +2,6 @@
 
 int main()
 {
-  return 0;  // A successful test! Let's report it on our dashboard.
+  /* A successful test! Let's report it on our dashboard. */
+  return 0;
 }

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -115,6 +115,19 @@
                 <!-- <cmake.generator>MSYS Makefiles</cmake.generator> -->
             </properties>
         </profile>
+		<profile>
+			<id>sunos</id>
+			<activation>
+				<os>
+					<name>sunos</name>
+				</os>
+			</activation>
+			<properties>
+				 <cmake.generator>Unix Makefiles</cmake.generator>
+				 <download.cmake>false</download.cmake>
+				 <cmake.root.dir>${cmake.root.dir}</cmake.root.dir>
+			</properties>
+		</profile>
 
         <!--
           Other cmake.generators

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -128,6 +128,19 @@
 				 <cmake.root.dir>${cmake.root.dir}</cmake.root.dir>
 			</properties>
 		</profile>
+		<profile>
+			<id>aix</id>
+			<activation>
+				<os>
+					<name>aix</name>
+				</os>
+			</activation>
+			<properties>
+				 <cmake.generator>Unix Makefiles</cmake.generator>
+				 <download.cmake>false</download.cmake>
+				 <cmake.root.dir>${cmake.root.dir}</cmake.root.dir>
+			</properties>
+		</profile>
 
         <!--
           Other cmake.generators

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/CMakeLists.txt
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.6.4)
-project(HelloTest)
+project(HelloTest LANGUAGES C)
 add_executable(hello-test main.c)
 
 # Turn on testing

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/main.c
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/main.c
@@ -2,5 +2,6 @@
 
 int main()
 {
-  return 1;  // A failed test, but that's what we expect.
+  /* A failed test, but that's what we expect. */
+  return 1;
 }

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -115,7 +115,19 @@
                 <!-- <cmake.generator>MSYS Makefiles</cmake.generator> -->
             </properties>
         </profile>
-
+		<profile>
+			<id>sunos</id>
+			<activation>
+				<os>
+					<name>sunos</name>
+				</os>
+			</activation>
+			<properties>
+				 <cmake.generator>Unix Makefiles</cmake.generator>
+				 <download.cmake>false</download.cmake>
+				 <cmake.root.dir>${cmake.root.dir}</cmake.root.dir>
+			</properties>
+		</profile>
         <!--
           Other cmake.generators
           http://www.cmake.org/cmake/help/v2.8.8/cmake.html#section_Generators

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -128,6 +128,19 @@
 				 <cmake.root.dir>${cmake.root.dir}</cmake.root.dir>
 			</properties>
 		</profile>
+		<profile>
+			<id>aix</id>
+			<activation>
+				<os>
+					<name>aix</name>
+				</os>
+			</activation>
+			<properties>
+				 <cmake.generator>Unix Makefiles</cmake.generator>
+				 <download.cmake>false</download.cmake>
+				 <cmake.root.dir>${cmake.root.dir}</cmake.root.dir>
+			</properties>
+		</profile>
         <!--
           Other cmake.generators
           http://www.cmake.org/cmake/help/v2.8.8/cmake.html#section_Generators

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,14 @@
 			</activation>
 		</profile>
 		<profile>
+			<id>aix</id>
+			<activation>
+				<os>
+					<name>aix</name>
+				</os>
+			</activation>
+		</profile>
+		<profile>
 			<id>sonatype-oss-release</id>
 			<build>
 				<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,14 @@
 			</activation>
 		</profile>
 		<profile>
+			<id>sunos</id>
+			<activation>
+				<os>
+					<name>sunos</name>
+				</os>
+			</activation>
+		</profile>
+		<profile>
 			<id>sonatype-oss-release</id>
 			<build>
 				<plugins>


### PR DESCRIPTION
I've edited the code so it will now build and execute on both Solaris and AIX (#12). The projects I was trying to build on these platforms using this plugin do now build successfully.

It doesn't download the binaries for these platforms since none are hosted on the CMake web site, so when building you do need to tell it where local copies are using -Dcmake.root.dir=... on the command line. I've not made it include those local copies when building the binaries artifact, so that remains empty.
