### PR TITLE
Removed profile activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
        - JAVA_HOME=$(/usr/libexec/java_home)
        - MAVEN_PROFILE="-Pmac-amd64"
 
+install: true
 script:
   - mvn install $MAVEN_PROFILE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 matrix:
   include:
    - os: linux
-     env: MAVEN_PROFILE=""
+     env: MAVEN_PROFILE="-Plinux-amd64"
      jdk: oraclejdk8
      addons:
        apt:
@@ -21,7 +21,7 @@ matrix:
            - cmake
            - gcc-multilib
    - os: linux
-     env: MAVEN_PROFILE=""
+     env: MAVEN_PROFILE="-Plinux-amd64"
      jdk: openjdk7
      addons:
        apt:
@@ -38,7 +38,9 @@ matrix:
            - gcc-multilib
    # Travis only supports jdk7 on OS X at the moment (and needs JAVA_HOME set)
    - os: osx
-     env: JAVA_HOME=$(/usr/libexec/java_home)
+     env:
+       - JAVA_HOME=$(/usr/libexec/java_home)
+       - MAVEN_PROFILE="-Pmac-amd64"
 
 script:
   - mvn install $MAVEN_PROFILE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,12 @@ matrix:
            - gcc-multilib
    - os: linux
      # Travis by default is 64 bit so we toggle to use the 32 bit libs
-     env: MAVEN_PROFILE="-Plinux32,-linux64"
+     env: MAVEN_PROFILE="-Plinux-i386"
      jdk: oraclejdk8
      addons:
        apt:
          packages:
+           - cmake
            - gcc-multilib
    - os: linux
      env: MAVEN_PROFILE=""
@@ -28,11 +29,12 @@ matrix:
            - gcc-multilib
    - os: linux
      # Travis by default is 64 bit so we toggle to use the 32 bit libs
-     env: MAVEN_PROFILE="-Plinux32,-linux64"
+     env: MAVEN_PROFILE="-Plinux-i386"
      jdk: openjdk7
      addons:
        apt:
          packages:
+           - cmake
            - gcc-multilib
    # Travis only supports jdk7 on OS X at the moment (and needs JAVA_HOME set)
    - os: osx

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
             <generator>
               <!-- One of the generators defined at https://cmake.org/cmake/help/v3.7/manual/cmake-generators.7.html -->
             </generator>
+            <classifier>
+              <!-- The classifier of the current platform. One of [windows32, windows64, linux64, linux32, mac64]. -->
+            </classifier>
             <environmentVariables>
               <key>value</key>
             </environmentVariables>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
               <!-- One of the generators defined at https://cmake.org/cmake/help/v3.7/manual/cmake-generators.7.html -->
             </generator>
             <classifier>
-              <!-- The classifier of the current platform. One of [windows32, windows64, linux64, linux32, mac64]. -->
+              <!-- The classifier of the current platform. One of [windows-i386, windows-amd64, linux-i386, linux-amd64, linux-arm, mac-amd64]. -->
             </classifier>
             <environmentVariables>
               <key>value</key>
@@ -126,23 +126,27 @@ To clean an old build, run:
 
 The following profiles are supported:
 
-* windows32
-* windows64
-* linux64
-* linux32
-* mac64
+* windows-i386
+* windows-amd64
+* linux-i386
+* linux-amd64
+* linux-arm
+* mac-amd64
 
 For instance, when building for 64-bit Windows machines, use:
 
     mvn -Pwindows64 install
 
-### Building Your Project on a Raspberry Pi
+### Using a local CMake installation
 
-CMake doesn't offer a pre-built version of their software for ARM machines, but Raspberry Pi distributions like Raspbian offer CMake as a part of the system's software packages. Simply set the `download.cmake` system property to `false` and the plugin will use the local installation:
+cmake.org doesn't provide binaries for some platforms, such as 32-bit Linux and Raspberry Pi. In such cases, users can install the binaries themselves (typically using package managers like `apt-get`) and point the plugin at them.
 
-    mvn -Ddownload.cmake=false clean install
+The following Maven profiles use local CMake installations:
 
-The plugin looks for the cmake under `${cmake.root.dir}/${cmake.child.dir}` and ctest under `${cmake.root.dir}/${cmake.ctest.dir}`. By default, `${cmake.root.dir}` resolves to `/usr`, `${cmake.child.dir}` to `/bin/cmake` and `${cmake.test.dir}` to `/`.
+    `linux-i386` corresponds to the 32-bit Linux platform.
+    `linux-arm` corresponds to the Rasbian (Raspberry Pi) platform.
+
+but you can configure this behavior for any platform by setting `${download.cmake}` to `false`. The plugin looks for cmake under `${cmake.root.dir}/${cmake.child.dir}` and ctest under `${cmake.root.dir}/${cmake.ctest.dir}`. By default, `${cmake.root.dir}` resolves to `/usr`, `${cmake.child.dir}` to `/bin/cmake` and `${cmake.test.dir}` to `/`.
 
 That's it! To learn more about CMake itself, consult the [CMake.org](https://cmake.org/) website.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Maven project for the CMake build system. It can be used by including it as a plugin within your Maven project's pom.xml file.
 
-This repository [originally lived]((https://code.google.com/p/cmake-maven-project/)) on Google Code and was migrated to GitHub (and Git) after Google Code shut down.
+This repository [originally lived](https://code.google.com/p/cmake-maven-project/) on Google Code and was migrated to GitHub (and Git) after Google Code shut down.
 
 ## Sample Usage
 
@@ -112,7 +112,7 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
 
 The following projects contain examples of how to use this plugin:
 
-https://bitbucket.org/cowwoc/requirements/src/238f37a385057a640acb8bec5452a425ab8e9ce0/native/pom.xml?at=dev-3.0.0&fileviewer=file-view-default
+requirements API: [maven profiles](https://bitbucket.org/cowwoc/requirements/src/238f37a385057a640acb8bec5452a425ab8e9ce0/pom.xml?at=dev-3.0.0&fileviewer=file-view-default) and [cmake plugin](https://bitbucket.org/cowwoc/requirements/src/238f37a385057a640acb8bec5452a425ab8e9ce0/native/pom.xml?at=dev-3.0.0&fileviewer=file-view-default)
 
 ### Building instructions
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
     <plugin>
       <groupId>com.googlecode.cmake-maven-project</groupId>
       <artifactId>cmake-maven-plugin</artifactId>
-      <version>3.4.1-b1</version>
+      <version>3.7.0-b1</version>
       <executions>
         <execution>
           <id>cmake-generate</id>
@@ -28,17 +28,17 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
               <!-- The directory write the project files to -->
             </targetPath>
             <generator>
-              <!-- One of the generators defined at http://www.cmake.org/cmake/help/v2.8.10/cmake.html#section_Generators -->
+              <!-- One of the generators defined at https://cmake.org/cmake/help/v3.7/manual/cmake-generators.7.html -->
             </generator>
             <environmentVariables>
               <key>value</key>
             </environmentVariables>
             <options>
               <!--
-                Optional: One or more options found at http://www.cmake.org/cmake/help/v2.8.10/cmake.html#section_Options
+                Optional: One or more options found at https://cmake.org/cmake/help/v3.7/manual/cmake.1.html
                 For example:
               -->
-              <option>-DBUILD_THIRDPARTY:bool=on</option> 
+              <option>-DBUILD_THIRDPARTY:bool=on</option>
             </options>
           </configuration>
         </execution>
@@ -50,7 +50,7 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
     <plugin>
       <groupId>com.googlecode.cmake-maven-project</groupId>
       <artifactId>cmake-maven-plugin</artifactId>
-      <version>3.4.1-b1</version>
+      <version>3.7.0-b1</version>
       <executions>
         <execution>
           <id>cmake-compile</id>
@@ -80,7 +80,7 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
     <plugin>
       <groupId>com.googlecode.cmake-maven-project</groupId>
       <artifactId>cmake-maven-plugin</artifactId>
-      <version>3.4.1-b1</version>
+      <version>3.7.0-b1</version>
       <executions>
         <execution>
           <id>cmake-test</id>
@@ -88,7 +88,7 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
             <goal>test</goal>
           </goals>
           <configuration>
-            <!-- "buildDirectory" is "targetPath" from the "generate" goal --> 
+            <!-- "buildDirectory" is "targetPath" from the "generate" goal -->
             <buildDirectory>${project.build.directory}</buildDirectory>
             <!-- Optional way to not fail the build on test failures -->
             <!-- <testFailureIgnore>true</testFailureIgnore> -->
@@ -105,119 +105,41 @@ This repository [originally lived]((https://code.google.com/p/cmake-maven-projec
       </executions>
     </plugin>
 
-### Configuring Platform-Specific Build Profiles
+### Examples
 
-You can use Maven profiles (in your project's pom.xml file) to enable platform-specific configurations. For example, the below changes the generator based on OS:
+The following projects contain examples of how to use this plugin:
 
-    <profiles>
-      <profile>
-        <id>linux64</id>
-        <activation>
-          <os>
-            <name>Linux</name>
-            <arch>!i386</arch>
-          </os>
-        </activation>
-        <properties>
-          <cmake.generator>Unix Makefiles</cmake.generator>
-        </properties>
-      </profile>
-      <profile>
-        <id>linux32</id>
-        <activation>
-          <os>
-            <name>Linux</name>
-            <arch>i386</arch>
-          </os>
-        </activation>
-        <properties>
-          <cmake.generator>Unix Makefiles</cmake.generator>
-        </properties>
-      </profile>
-      <profile>
-        <id>mac64</id>
-        <activation>
-          <os>
-            <name>Mac OS X</name>
-          </os>
-        </activation>
-        <properties>
-          <cmake.generator>xcode</cmake.generator>
-        </properties>
-      </profile>
-      <profile>
-        <id>windows</id>
-        <activation>
-          <os>
-            <family>windows</family>
-          </os>
-        </activation>
-        <properties>
-          <!-- with cygwin -->
-          <cmake.generator>Unix Makefiles</cmake.generator>
-          <!-- with MinGW -->
-          <!-- <cmake.generator>MinGW Makefiles</cmake.generator> -->
-          <!-- with MSYS -->
-          <!-- <cmake.generator>MSYS Makefiles</cmake.generator> -->
-        </properties>
-      </profile>
-    </profiles>
+https://bitbucket.org/cowwoc/requirements/src/238f37a385057a640acb8bec5452a425ab8e9ce0/native/pom.xml?at=dev-3.0.0&fileviewer=file-view-default
 
+### Building instructions
 
-### Building Your Project Using Version 2.8.11-b4 and Later
+To build the plugin, run:
 
-Since version 2.8.11-b4, CMake-Maven-Project will use OS activation to determine which profile to use. If you're building on a Linux system, it will automatically select the 'linux' profile; if you're running on a Windows system, it will automatically select the 'windows' profile. You simply have to build your project in the standard Maven way:
-
-    mvn install
-
-OS profile activation can be overridden (if you have a Windows cross-compiling setup on a 64 bit Linux machine, for instance). To select the Windows profile on a 64 bit Linux machine, use:
-
-    mvn -Pwindows,-linux64 install
-
-This removes the 'linux64' profile and adds the 'windows' one.
-
-Since version 3.4.1-b1, the following profiles are supported:
-
-* windows
-* linux64
-* linux32
-* mac64
-
-Between versions 2.8.11-b4 and 3.4.1-b1, the supported build profiles were:
-
-* windows
-* linux
-* mac
+    mvn -P<profile> install
 
 To clean an old build, run:
 
     mvn -P<profile> clean
 
-### Building Your Project Using Version 2.8.11-b3 and Earlier
-
-To build your project using an earlier version of CMake-Maven-Project, you will need to supply the OS profile you want to use. It will not be auto-detected.
-
-    mvn -P<profile> install
-
-So, for example, to build on 64 bit Linux:
-
-    mvn -Plinux install
-
 The following profiles are supported:
 
-* windows
-* linux
-* mac
+* windows32
+* windows64
+* linux64
+* linux32
+* mac64
 
-### Building Your Project on a Raspberry Pi Using Version 3.4.1-b2 and Later
+For instance, when building for 64-bit Windows machines, use:
 
-Your CMake project can be built with cmake-maven-project on a Raspberry Pi with just a couple of additional steps. CMake doesn't offer a pre-built version of their software for ARM machines, but Raspberry Pi distributions like Raspbian offer CMake as a part of the system's software packages. Since cmake-maven-project version 3.4.1-b2, a Maven build can be configured to use the system's CMake on a Raspberry Pi system by supplying additional arguments at the point of running the build.
+    mvn -Pwindows64 install
 
-The only required additional argument to tell cmake-maven-project to use the local CMake instead of a profile in the build's pom.xml file is: `-Ddownload.cmake=false`. For instance, to build a clean version of a project on a Raspberry Pi with CMake already installed locally, you'd run:
+### Building Your Project on a Raspberry Pi
+
+CMake doesn't offer a pre-built version of their software for ARM machines, but Raspberry Pi distributions like Raspbian offer CMake as a part of the system's software packages. Simply set the `download.cmake` system property to `false` and the plugin will use the local installation:
 
     mvn -Ddownload.cmake=false clean install
 
-There are some optional additional arguments that can also be used if needed: `-Dcmake.root.dir`, `-Dcmake.child.dir` and `-Dcmake.ctest.dir`. These are useful if your project wants to define different CMake root, child, or test directories for a build. Their values would be directory locations for each of those parameters (which would be specific to your project).
+The plugin looks for the cmake under `${cmake.root.dir}/${cmake.child.dir}` and ctest under `${cmake.root.dir}/${cmake.ctest.dir}`. By default, `${cmake.root.dir}` resolves to `/usr`, `${cmake.child.dir}` to `/bin/cmake` and `${cmake.test.dir}` to `/`.
 
 That's it! To learn more about CMake itself, consult the [CMake.org](https://cmake.org/) website.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This repository [originally lived](https://code.google.com/p/cmake-maven-project
 
 The following projects contain examples of how to use this plugin:
 
-requirements API: [maven profiles](https://bitbucket.org/cowwoc/requirements/src/238f37a385057a640acb8bec5452a425ab8e9ce0/pom.xml?at=dev-3.0.0&fileviewer=file-view-default) and [cmake plugin](https://bitbucket.org/cowwoc/requirements/src/238f37a385057a640acb8bec5452a425ab8e9ce0/native/pom.xml?at=dev-3.0.0&fileviewer=file-view-default)
+[Requirements API](https://bitbucket.org/cowwoc/requirements/src/1d6416782875b6d412903c5b7d8fd3686e63927b/native/pom.xml?at=dev-3.0.0&fileviewer=file-view-default#pom.xml-166)
 
 ### Building instructions
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The following profiles are supported:
 
 For instance, when building for 64-bit Windows machines, use:
 
-    mvn -Pwindows64 install
+    mvn -Pwindows-amd64 install
 
 ### Using a local CMake installation
 

--- a/cmake-binaries-plugin/pom.xml
+++ b/cmake-binaries-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.googlecode.cmake-maven-project</groupId>
 		<artifactId>cmake</artifactId>
-		<version>3.6.2-b1-SNAPSHOT</version>
+		<version>3.7.0-b1-SNAPSHOT</version>
 	</parent>
 	<artifactId>cmake-binaries-plugin</artifactId>
 	<packaging>maven-plugin</packaging>

--- a/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
+++ b/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
@@ -95,8 +95,11 @@ public class GetBinariesMojo
 
 		switch (classifier)
 		{
-			case "windows":
+			case "windows32":
 				suffix = "win32-x86.zip";
+				break;
+			case "windows64":
+				suffix = "win64-x64.zip";
 				break;
 			case "linux32":
 				suffix = "Linux-i386.tar.gz";

--- a/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
+++ b/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
@@ -95,19 +95,16 @@ public class GetBinariesMojo
 
 		switch (classifier)
 		{
-			case "windows32":
+			case "windows-i386":
 				suffix = "win32-x86.zip";
 				break;
-			case "windows64":
+			case "windows-amd64":
 				suffix = "win64-x64.zip";
 				break;
-			case "linux32":
-				suffix = "Linux-i386.tar.gz";
-				break;
-			case "linux64":
+			case "linux-amd64":
 				suffix = "Linux-x86_64.tar.gz";
 				break;
-			case "mac64":
+			case "mac-amd64":
 				suffix = "Darwin-x86_64.tar.gz";
 				break;
 			default:

--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -12,23 +12,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.cmake-maven-project</groupId>
-				<artifactId>cmake-binaries-plugin</artifactId>
-				<version>${project.version}</version>
-				<executions>
-					<execution>
-						<id>cmake-binaries</id>
-						<goals>
-							<goal>get-binaries</goal>
-						</goals>
-						<configuration>
-							<classifier>${cmake.classifier}</classifier>
-							<skip>${cmake.download}</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.0.2</version>
 				<configuration>
@@ -62,8 +45,7 @@
 										<echo>* linux-amd64</echo>
 										<echo>* mac-amd64</echo>
 										<echo/>
-										<echo>For instance: mvn -Pwindows64 install</echo>
-										<fail/>
+										<echo>For instance: mvn -Pwindows-amd64 install</echo>
 									</tasks>
 								</configuration>
 							</execution>
@@ -77,24 +59,108 @@
 			<properties>
 				<cmake.classifier>windows-i386</cmake.classifier>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.googlecode.cmake-maven-project</groupId>
+						<artifactId>cmake-binaries-plugin</artifactId>
+						<version>${project.version}</version>
+						<executions>
+							<execution>
+								<id>cmake-binaries</id>
+								<goals>
+									<goal>get-binaries</goal>
+								</goals>
+								<configuration>
+									<classifier>${cmake.classifier}</classifier>
+									<skip>${cmake.download}</skip>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>windows-amd64</id>
 			<properties>
 				<cmake.classifier>windows-amd64</cmake.classifier>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.googlecode.cmake-maven-project</groupId>
+						<artifactId>cmake-binaries-plugin</artifactId>
+						<version>${project.version}</version>
+						<executions>
+							<execution>
+								<id>cmake-binaries</id>
+								<goals>
+									<goal>get-binaries</goal>
+								</goals>
+								<configuration>
+									<classifier>${cmake.classifier}</classifier>
+									<skip>${cmake.download}</skip>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>linux-amd64</id>
 			<properties>
 				<cmake.classifier>linux-amd64</cmake.classifier>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.googlecode.cmake-maven-project</groupId>
+						<artifactId>cmake-binaries-plugin</artifactId>
+						<version>${project.version}</version>
+						<executions>
+							<execution>
+								<id>cmake-binaries</id>
+								<goals>
+									<goal>get-binaries</goal>
+								</goals>
+								<configuration>
+									<classifier>${cmake.classifier}</classifier>
+									<skip>${cmake.download}</skip>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>mac-amd64</id>
 			<properties>
 				<cmake.classifier>mac-amd64</cmake.classifier>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.googlecode.cmake-maven-project</groupId>
+						<artifactId>cmake-binaries-plugin</artifactId>
+						<version>${project.version}</version>
+						<executions>
+							<execution>
+								<id>cmake-binaries</id>
+								<goals>
+									<goal>get-binaries</goal>
+								</goals>
+								<configuration>
+									<classifier>${cmake.classifier}</classifier>
+									<skip>${cmake.download}</skip>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 </project>

--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.googlecode.cmake-maven-project</groupId>
 		<artifactId>cmake</artifactId>
-		<version>3.6.2-b1-SNAPSHOT</version>
+		<version>3.7.0-b1-SNAPSHOT</version>
 	</parent>
 	<artifactId>cmake-binaries</artifactId>
 	<name>CMake Binaries</name>
@@ -23,6 +23,7 @@
 						</goals>
 						<configuration>
 							<classifier>${cmake.classifier}</classifier>
+							<skip>${cmake.download}</skip>
 						</configuration>
 					</execution>
 				</executions>
@@ -37,31 +38,35 @@
 			</plugin>
 		</plugins>
 	</build>
-	<!--
-		OS profile activation is triggered by the system's operating system.
-		This can be overridden by substracting a profile on the command line.
-
-		For instance: mvn -Pwindows,-linux64 install
-
-		To accept the OS activated profile, just use: mvn install
-	-->
 	<profiles>
 		<profile>
-			<id>pick-a-profile</id>
+			<id>list-profiles</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<build>
 				<plugins>
 					<plugin>
-						<artifactId>maven-help-plugin</artifactId>
-						<version>2.2</version>
+						<artifactId>maven-antrun-plugin</artifactId>
 						<executions>
 							<execution>
-								<goals>
-									<goal>all-profiles</goal>
-								</goals>
 								<phase>validate</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<tasks>
+										<echo>please activate one of the following profiles:</echo>
+										<echo>* windows32</echo>
+										<echo>* windows64</echo>
+										<echo>* linux32</echo>
+										<echo>* linux64</echo>
+										<echo>* mac64</echo>
+										<echo/>
+										<echo>For instance: mvn -Pwindows64 install</echo>
+										<fail/>
+									</tasks>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>
@@ -69,48 +74,31 @@
 			</build>
 		</profile>
 		<profile>
-			<id>windows</id>
-			<activation>
-				<os>
-					<family>windows</family>
-				</os>
-			</activation>
+			<id>windows32</id>
 			<properties>
-				<cmake.classifier>windows</cmake.classifier>
+				<cmake.classifier>windows32</cmake.classifier>
+			</properties>
+		</profile>
+		<profile>
+			<id>windows64</id>
+			<properties>
+				<cmake.classifier>windows64</cmake.classifier>
 			</properties>
 		</profile>
 		<profile>
 			<id>linux32</id>
-			<activation>
-				<os>
-					<name>Linux</name>
-					<arch>i386</arch>
-				</os>
-			</activation>
 			<properties>
 				<cmake.classifier>linux32</cmake.classifier>
 			</properties>
 		</profile>
 		<profile>
 			<id>linux64</id>
-			<activation>
-				<os>
-					<name>Linux</name>
-					<arch>!i386</arch>
-				</os>
-			</activation>
 			<properties>
 				<cmake.classifier>linux64</cmake.classifier>
 			</properties>
 		</profile>
 		<profile>
 			<id>mac64</id>
-			<activation>
-				<os>
-					<name>Mac OS X</name>
-					<arch>x86_64</arch>
-				</os>
-			</activation>
 			<properties>
 				<cmake.classifier>mac64</cmake.classifier>
 			</properties>

--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -56,12 +56,11 @@
 								</goals>
 								<configuration>
 									<tasks>
-										<echo>please activate one of the following profiles:</echo>
-										<echo>* windows32</echo>
-										<echo>* windows64</echo>
-										<echo>* linux32</echo>
-										<echo>* linux64</echo>
-										<echo>* mac64</echo>
+										<echo>Please activate one of the following profiles:</echo>
+										<echo>* windows-i386</echo>
+										<echo>* windows-amd64</echo>
+										<echo>* linux-amd64</echo>
+										<echo>* mac-amd64</echo>
 										<echo/>
 										<echo>For instance: mvn -Pwindows64 install</echo>
 										<fail/>
@@ -74,33 +73,27 @@
 			</build>
 		</profile>
 		<profile>
-			<id>windows32</id>
+			<id>windows-i386</id>
 			<properties>
-				<cmake.classifier>windows32</cmake.classifier>
+				<cmake.classifier>windows-i386</cmake.classifier>
 			</properties>
 		</profile>
 		<profile>
-			<id>windows64</id>
+			<id>windows-amd64</id>
 			<properties>
-				<cmake.classifier>windows64</cmake.classifier>
+				<cmake.classifier>windows-amd64</cmake.classifier>
 			</properties>
 		</profile>
 		<profile>
-			<id>linux32</id>
+			<id>linux-amd64</id>
 			<properties>
-				<cmake.classifier>linux32</cmake.classifier>
+				<cmake.classifier>linux-amd64</cmake.classifier>
 			</properties>
 		</profile>
 		<profile>
-			<id>linux64</id>
+			<id>mac-amd64</id>
 			<properties>
-				<cmake.classifier>linux64</cmake.classifier>
-			</properties>
-		</profile>
-		<profile>
-			<id>mac64</id>
-			<properties>
-				<cmake.classifier>mac64</cmake.classifier>
+				<cmake.classifier>mac-amd64</cmake.classifier>
 			</properties>
 		</profile>
 	</profiles>

--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -12,6 +12,23 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>com.googlecode.cmake-maven-project</groupId>
+				<artifactId>cmake-binaries-plugin</artifactId>
+				<version>${project.version}</version>
+				<executions>
+					<execution>
+						<id>cmake-binaries</id>
+						<goals>
+							<goal>get-binaries</goal>
+						</goals>
+						<configuration>
+							<classifier>${cmake.classifier}</classifier>
+							<skip>${cmake.download}</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.0.2</version>
 				<configuration>
@@ -40,38 +57,18 @@
 								</goals>
 								<configuration>
 									<target>
-										<taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-
-										<if>
-											<and>
-												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
-												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
-											</and>
-											<then>
-												<echo>Travis is priming dependenices, skipping the build.</echo>
-											</then>
-											<else>
-												<echo>Please activate one of the following profiles:</echo>
-												<echo>* windows-i386</echo>
-												<echo>* windows-amd64</echo>
-												<echo>* linux-amd64</echo>
-												<echo>* mac-amd64</echo>
-												<echo/>
-												<echo>For instance: mvn -Pwindows-amd64 install</echo>
-												<fail/>
-											</else>
-										</if>
+										<echo>Please activate one of the following profiles:</echo>
+										<echo>* windows-i386</echo>
+										<echo>* windows-amd64</echo>
+										<echo>* linux-amd64</echo>
+										<echo>* mac-amd64</echo>
+										<echo/>
+										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+										<fail/>
 									</target>
 								</configuration>
 							</execution>
 						</executions>
-						<dependencies>
-							<dependency>
-								<groupId>ant-contrib</groupId>
-								<artifactId>ant-contrib</artifactId>
-								<version>20020829</version>
-							</dependency>
-						</dependencies>
 					</plugin>
 				</plugins>
 			</build>
@@ -81,108 +78,24 @@
 			<properties>
 				<cmake.classifier>windows-i386</cmake.classifier>
 			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.googlecode.cmake-maven-project</groupId>
-						<artifactId>cmake-binaries-plugin</artifactId>
-						<version>${project.version}</version>
-						<executions>
-							<execution>
-								<id>cmake-binaries</id>
-								<goals>
-									<goal>get-binaries</goal>
-								</goals>
-								<configuration>
-									<classifier>${cmake.classifier}</classifier>
-									<skip>${cmake.download}</skip>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 		<profile>
 			<id>windows-amd64</id>
 			<properties>
 				<cmake.classifier>windows-amd64</cmake.classifier>
 			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.googlecode.cmake-maven-project</groupId>
-						<artifactId>cmake-binaries-plugin</artifactId>
-						<version>${project.version}</version>
-						<executions>
-							<execution>
-								<id>cmake-binaries</id>
-								<goals>
-									<goal>get-binaries</goal>
-								</goals>
-								<configuration>
-									<classifier>${cmake.classifier}</classifier>
-									<skip>${cmake.download}</skip>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 		<profile>
 			<id>linux-amd64</id>
 			<properties>
 				<cmake.classifier>linux-amd64</cmake.classifier>
 			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.googlecode.cmake-maven-project</groupId>
-						<artifactId>cmake-binaries-plugin</artifactId>
-						<version>${project.version}</version>
-						<executions>
-							<execution>
-								<id>cmake-binaries</id>
-								<goals>
-									<goal>get-binaries</goal>
-								</goals>
-								<configuration>
-									<classifier>${cmake.classifier}</classifier>
-									<skip>${cmake.download}</skip>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 		<profile>
 			<id>mac-amd64</id>
 			<properties>
 				<cmake.classifier>mac-amd64</cmake.classifier>
 			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.googlecode.cmake-maven-project</groupId>
-						<artifactId>cmake-binaries-plugin</artifactId>
-						<version>${project.version}</version>
-						<executions>
-							<execution>
-								<id>cmake-binaries</id>
-								<goals>
-									<goal>get-binaries</goal>
-								</goals>
-								<configuration>
-									<classifier>${cmake.classifier}</classifier>
-									<skip>${cmake.download}</skip>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 	</profiles>
 </project>

--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -31,6 +31,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.8</version>
 						<executions>
 							<execution>
 								<phase>validate</phase>
@@ -38,27 +39,39 @@
 									<goal>run</goal>
 								</goals>
 								<configuration>
-									<tasks>
-										<echo>Please activate one of the following profiles:</echo>
-										<echo>* windows-i386</echo>
-										<echo>* windows-amd64</echo>
-										<echo>* linux-amd64</echo>
-										<echo>* mac-amd64</echo>
-										<echo/>
-										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+									<target>
+										<taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
 
-										<!-- Avoid failing the build when Travis primes the build without a Maven profile -->
-										<condition property="is.travis">
+										<if>
 											<and>
 												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
 												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
 											</and>
-										</condition>
-										<fail unless="is.travis"/>
-									</tasks>
+											<then>
+												<echo>Travis is priming dependenices, skipping the build.</echo>
+											</then>
+											<else>
+												<echo>Please activate one of the following profiles:</echo>
+												<echo>* windows-i386</echo>
+												<echo>* windows-amd64</echo>
+												<echo>* linux-amd64</echo>
+												<echo>* mac-amd64</echo>
+												<echo/>
+												<echo>For instance: mvn -Pwindows-amd64 install</echo>
+												<fail/>
+											</else>
+										</if>
+									</target>
 								</configuration>
 							</execution>
 						</executions>
+						<dependencies>
+							<dependency>
+								<groupId>ant-contrib</groupId>
+								<artifactId>ant-contrib</artifactId>
+								<version>20020829</version>
+							</dependency>
+						</dependencies>
 					</plugin>
 				</plugins>
 			</build>

--- a/cmake-binaries/pom.xml
+++ b/cmake-binaries/pom.xml
@@ -46,6 +46,15 @@
 										<echo>* mac-amd64</echo>
 										<echo/>
 										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+
+										<!-- Avoid failing the build when Travis primes the build without a Maven profile -->
+										<condition property="is.travis">
+											<and>
+												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
+												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
+											</and>
+										</condition>
+										<fail unless="is.travis"/>
 									</tasks>
 								</configuration>
 							</execution>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -223,8 +223,7 @@
 										<echo>* linux-arm</echo>
 										<echo>* mac-amd64</echo>
 										<echo/>
-										<echo>For instance: mvn -Pwindows64 install</echo>
-										<fail/>
+										<echo>For instance: mvn -Pwindows-amd64 install</echo>
 									</tasks>
 								</configuration>
 							</execution>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -216,40 +216,20 @@
 								</goals>
 								<configuration>
 									<target>
-										<taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-
-										<if>
-											<and>
-												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
-												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
-											</and>
-											<then>
-												<echo>Travis is priming dependenices, skipping the build.</echo>
-											</then>
-											<else>
-												<echo>Please activate one of the following profiles:</echo>
-												<echo>* windows-i386</echo>
-												<echo>* windows-amd64</echo>
-												<echo>* linux-i386</echo>
-												<echo>* linux-amd64</echo>
-												<echo>* linux-arm</echo>
-												<echo>* mac-amd64</echo>
-												<echo/>
-												<echo>For instance: mvn -Pwindows-amd64 install</echo>
-												<fail/>
-											</else>
-										</if>
+										<echo>Please activate one of the following profiles:</echo>
+										<echo>* windows-i386</echo>
+										<echo>* windows-amd64</echo>
+										<echo>* linux-i386</echo>
+										<echo>* linux-amd64</echo>
+										<echo>* linux-arm</echo>
+										<echo>* mac-amd64</echo>
+										<echo/>
+										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+										<fail/>
 									</target>
 								</configuration>
 							</execution>
 						</executions>
-						<dependencies>
-							<dependency>
-								<groupId>ant-contrib</groupId>
-								<artifactId>ant-contrib</artifactId>
-								<version>20020829</version>
-							</dependency>
-						</dependencies>
 					</plugin>
 				</plugins>
 			</build>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -126,13 +126,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19.1</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit47</artifactId>
-						<version>2.19.1</version>
-					</dependency>
-				</dependencies>
 				<configuration>
 					<!-- Our tests shouldn't be run as unit tests -->
 					<excludes>
@@ -223,11 +216,12 @@
 								<configuration>
 									<tasks>
 										<echo>Please activate one of the following profiles:</echo>
-										<echo>* windows32</echo>
-										<echo>* windows64</echo>
-										<echo>* linux32</echo>
-										<echo>* linux64</echo>
-										<echo>* mac64</echo>
+										<echo>* windows-i386</echo>
+										<echo>* windows-amd64</echo>
+										<echo>* linux-i386</echo>
+										<echo>* linux-amd64</echo>
+										<echo>* linux-arm</echo>
+										<echo>* mac-amd64</echo>
 										<echo/>
 										<echo>For instance: mvn -Pwindows64 install</echo>
 										<fail/>
@@ -240,9 +234,9 @@
 			</build>
 		</profile>
 		<profile>
-			<id>windows32</id>
+			<id>windows-i386</id>
 			<properties>
-				<cmake.classifier>windows32</cmake.classifier>
+				<cmake.classifier>windows-i386</cmake.classifier>
 			</properties>
 			<dependencies>
 				<dependency>
@@ -255,9 +249,9 @@
 			</dependencies>
 		</profile>
 		<profile>
-			<id>windows64</id>
+			<id>windows-amd64</id>
 			<properties>
-				<cmake.classifier>windows64</cmake.classifier>
+				<cmake.classifier>windows-amd64</cmake.classifier>
 			</properties>
 			<dependencies>
 				<dependency>
@@ -270,9 +264,16 @@
 			</dependencies>
 		</profile>
 		<profile>
-			<id>linux32</id>
+			<id>linux-i386</id>
 			<properties>
-				<cmake.classifier>linux32</cmake.classifier>
+				<cmake.classifier>linux-i386</cmake.classifier>
+				<download.cmake>false</download.cmake>
+			</properties>
+		</profile>
+		<profile>
+			<id>linux-amd64</id>
+			<properties>
+				<cmake.classifier>linux-amd64</cmake.classifier>
 			</properties>
 			<dependencies>
 				<dependency>
@@ -285,24 +286,16 @@
 			</dependencies>
 		</profile>
 		<profile>
-			<id>linux64</id>
+			<id>linux-arm</id>
 			<properties>
-				<cmake.classifier>linux64</cmake.classifier>
+				<cmake.classifier>linux-arm</cmake.classifier>
+				<download.cmake>false</download.cmake>
 			</properties>
-			<dependencies>
-				<dependency>
-					<groupId>${project.groupId}</groupId>
-					<artifactId>cmake-binaries</artifactId>
-					<version>${project.version}</version>
-					<classifier>${cmake.classifier}</classifier>
-					<scope>test</scope>
-				</dependency>
-			</dependencies>
 		</profile>
 		<profile>
-			<id>mac64</id>
+			<id>mac-amd64</id>
 			<properties>
-				<cmake.classifier>mac64</cmake.classifier>
+				<cmake.classifier>mac-amd64</cmake.classifier>
 			</properties>
 			<dependencies>
 				<dependency>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -207,6 +207,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.8</version>
 						<executions>
 							<execution>
 								<phase>validate</phase>
@@ -214,29 +215,41 @@
 									<goal>run</goal>
 								</goals>
 								<configuration>
-									<tasks>
-										<echo>Please activate one of the following profiles:</echo>
-										<echo>* windows-i386</echo>
-										<echo>* windows-amd64</echo>
-										<echo>* linux-i386</echo>
-										<echo>* linux-amd64</echo>
-										<echo>* linux-arm</echo>
-										<echo>* mac-amd64</echo>
-										<echo/>
-										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+									<target>
+										<taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
 
-										<!-- Avoid failing the build when Travis primes the build without a Maven profile -->
-										<condition property="is.travis">
+										<if>
 											<and>
 												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
 												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
 											</and>
-										</condition>
-										<fail unless="is.travis"/>
-									</tasks>
+											<then>
+												<echo>Travis is priming dependenices, skipping the build.</echo>
+											</then>
+											<else>
+												<echo>Please activate one of the following profiles:</echo>
+												<echo>* windows-i386</echo>
+												<echo>* windows-amd64</echo>
+												<echo>* linux-i386</echo>
+												<echo>* linux-amd64</echo>
+												<echo>* linux-arm</echo>
+												<echo>* mac-amd64</echo>
+												<echo/>
+												<echo>For instance: mvn -Pwindows-amd64 install</echo>
+												<fail/>
+											</else>
+										</if>
+									</target>
 								</configuration>
 							</execution>
 						</executions>
+						<dependencies>
+							<dependency>
+								<groupId>ant-contrib</groupId>
+								<artifactId>ant-contrib</artifactId>
+								<version>20020829</version>
+							</dependency>
+						</dependencies>
 					</plugin>
 				</plugins>
 			</build>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -224,6 +224,15 @@
 										<echo>* mac-amd64</echo>
 										<echo/>
 										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+
+										<!-- Avoid failing the build when Travis primes the build without a Maven profile -->
+										<condition property="is.travis">
+											<and>
+												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
+												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
+											</and>
+										</condition>
+										<fail unless="is.travis"/>
 									</tasks>
 								</configuration>
 							</execution>

--- a/cmake-maven-plugin/pom.xml
+++ b/cmake-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.googlecode.cmake-maven-project</groupId>
 		<artifactId>cmake</artifactId>
-		<version>3.6.2-b1-SNAPSHOT</version>
+		<version>3.7.0-b1-SNAPSHOT</version>
 	</parent>
 	<artifactId>cmake-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
@@ -102,7 +102,7 @@
 						<goals>
 							<goal>copy-dependencies</goal>
 							<!-- There is a go-offline goal but it's broken
-								http://jira.codehaus.org/browse/MDEP-82 -->
+							http://jira.codehaus.org/browse/MDEP-82 -->
 						</goals>
 						<configuration>
 							<artifactItems>
@@ -197,13 +197,6 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>cmake-binaries</artifactId>
-			<version>${project.version}</version>
-			<classifier>${cmake.classifier}</classifier>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<!-- Run tests from ${test-repo} repository instead of the local repo -->
@@ -211,31 +204,35 @@
 		<test-repo>${project.build.directory}/test-classes/test-repo</test-repo>
 	</properties>
 
-	<!--
-		OS profile activation is triggered by the system's operating system.
-		This can be overridden by substracting a profile on the command line.
-
-		For instance: mvn -Pwindows,-linux64 install
-
-		To accept the OS activated profile, just use: mvn install
-	-->
 	<profiles>
 		<profile>
-			<id>pick-a-profile</id>
+			<id>list-profiles</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<build>
 				<plugins>
 					<plugin>
-						<artifactId>maven-help-plugin</artifactId>
-						<version>2.2</version>
+						<artifactId>maven-antrun-plugin</artifactId>
 						<executions>
 							<execution>
-								<goals>
-									<goal>all-profiles</goal>
-								</goals>
 								<phase>validate</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<tasks>
+										<echo>Please activate one of the following profiles:</echo>
+										<echo>* windows32</echo>
+										<echo>* windows64</echo>
+										<echo>* linux32</echo>
+										<echo>* linux64</echo>
+										<echo>* mac64</echo>
+										<echo/>
+										<echo>For instance: mvn -Pwindows64 install</echo>
+										<fail/>
+									</tasks>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>
@@ -243,51 +240,79 @@
 			</build>
 		</profile>
 		<profile>
-			<id>windows</id>
-			<activation>
-				<os>
-					<family>windows</family>
-				</os>
-			</activation>
+			<id>windows32</id>
 			<properties>
-				<cmake.classifier>windows</cmake.classifier>
+				<cmake.classifier>windows32</cmake.classifier>
 			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>cmake-binaries</artifactId>
+					<version>${project.version}</version>
+					<classifier>${cmake.classifier}</classifier>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>windows64</id>
+			<properties>
+				<cmake.classifier>windows64</cmake.classifier>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>cmake-binaries</artifactId>
+					<version>${project.version}</version>
+					<classifier>${cmake.classifier}</classifier>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 		<profile>
 			<id>linux32</id>
-			<activation>
-				<os>
-					<name>Linux</name>
-					<arch>i386</arch>
-				</os>
-			</activation>
 			<properties>
 				<cmake.classifier>linux32</cmake.classifier>
 			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>cmake-binaries</artifactId>
+					<version>${project.version}</version>
+					<classifier>${cmake.classifier}</classifier>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 		<profile>
 			<id>linux64</id>
-			<activation>
-				<os>
-					<name>Linux</name>
-					<arch>!i386</arch>
-				</os>
-			</activation>
 			<properties>
 				<cmake.classifier>linux64</cmake.classifier>
 			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>cmake-binaries</artifactId>
+					<version>${project.version}</version>
+					<classifier>${cmake.classifier}</classifier>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 		<profile>
 			<id>mac64</id>
-			<activation>
-				<os>
-					<name>Mac OS X</name>
-					<arch>x86_64</arch>
-				</os>
-			</activation>
 			<properties>
 				<cmake.classifier>mac64</cmake.classifier>
 			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>cmake-binaries</artifactId>
+					<version>${project.version}</version>
+					<classifier>${cmake.classifier}</classifier>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 	</profiles>
 </project>

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/CompileMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/CompileMojo.java
@@ -94,6 +94,8 @@ public class CompileMojo
 			if (!projectDirectory.isDirectory())
 				throw new MojoExecutionException(projectDirectory.getAbsolutePath() + " must be a directory");
 
+			// We assume that someone else has extracted the cmake binaries beforehand (e.g. the
+			// "generate" mojo).
 			File cmakeFile = downloadBinaries ? new File(project.getBuild().getDirectory(),
 				"dependency/cmake/bin/cmake")
 				: new File(cmakeRootDir + "/" + cmakeChildDir);

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
@@ -45,7 +45,9 @@ public class GenerateMojo
 	extends AbstractMojo
 {
 	/**
-	 * The release platform.
+	 * The classifier of the current platform.
+	 * <p>
+	 * One of [windows32, windows64, linux64, linux32, mac64].
 	 */
 	@SuppressWarnings("UWF_UNWRITTEN_FIELD")
 	@Parameter(property = "classifier", readonly = true, required = true)

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/GenerateMojo.java
@@ -13,11 +13,13 @@ package com.googlecode.cmakemavenproject;
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
@@ -44,13 +46,15 @@ import org.twdata.maven.mojoexecutor.MojoExecutor.ExecutionEnvironment;
 public class GenerateMojo
 	extends AbstractMojo
 {
+	private static final Set<String> VALID_CLASSIFIERS = ImmutableSet.of("windows-i386",
+		"windows-amd64", "linux-i386", "linux-amd64", "linux-arm", "mac-amd64");
 	/**
 	 * The classifier of the current platform.
 	 * <p>
-	 * One of [windows32, windows64, linux64, linux32, mac64].
+	 * One of [windows-i386, windows-amd64, linux-i386, linux-amd64, linux-arm, mac-amd64].
 	 */
 	@SuppressWarnings("UWF_UNWRITTEN_FIELD")
-	@Parameter(property = "classifier", readonly = true, required = true)
+	@Parameter(property = "classifier", readonly = true)
 	private String classifier;
 	/**
 	 * /**
@@ -117,38 +121,45 @@ public class GenerateMojo
 	{
 		try
 		{
-			if (!downloadBinaries)
-				getLog().info(" **** Using Native CMake");
-			PluginDescriptor pluginDescriptor = (PluginDescriptor) getPluginContext().
-				get("pluginDescriptor");
-			String groupId = pluginDescriptor.getGroupId();
-			String version = pluginDescriptor.getVersion();
 			if (!targetPath.exists() && !targetPath.mkdirs())
 				throw new MojoExecutionException("Cannot create " + targetPath.getAbsolutePath());
 
-			File cmakeDir = downloadBinaries ? new File(project.getBuild().getDirectory(),
-				"dependency/cmake") : new File(cmakeRootDir);
-			if (!downloadBinaries)
-				getLog().info(" **** Using Native CMake");
-
-			String binariesArtifact = "cmake-binaries";
-
-			Element groupIdElement = new Element("groupId", groupId);
-			Element artifactIdElement = new Element("artifactId", binariesArtifact);
-			Element versionElement = new Element("version", version);
-			Element classifierElement = new Element("classifier", classifier);
-			Element outputDirectoryElement = new Element("outputDirectory", cmakeDir.getAbsolutePath());
-			Element artifactItemElement = new Element("artifactItem", groupIdElement, artifactIdElement,
-				versionElement, classifierElement, outputDirectoryElement);
-			Element artifactItemsItem = new Element("artifactItems", artifactItemElement);
-			Xpp3Dom configuration = MojoExecutor.configuration(artifactItemsItem);
+			File cmakeDir;
 			if (downloadBinaries)
 			{
+				getLog().info("Downloading binaries");
+				cmakeDir = new File(project.getBuild().getDirectory(), "dependency/cmake");
+				if (classifier == null)
+					throw new MojoExecutionException("\"classifier\" must be set");
+				if (!VALID_CLASSIFIERS.contains(classifier))
+				{
+					throw new MojoExecutionException("\"classifier\" must be one of " + VALID_CLASSIFIERS +
+						"\nActual: " + classifier);
+				}
+				PluginDescriptor pluginDescriptor = (PluginDescriptor) getPluginContext().
+					get("pluginDescriptor");
+				String groupId = pluginDescriptor.getGroupId();
+				String version = pluginDescriptor.getVersion();
+				String binariesArtifact = "cmake-binaries";
+				Element groupIdElement = new Element("groupId", groupId);
+				Element artifactIdElement = new Element("artifactId", binariesArtifact);
+				Element versionElement = new Element("version", version);
+				Element classifierElement = new Element("classifier", classifier);
+				Element outputDirectoryElement = new Element("outputDirectory", cmakeDir.getAbsolutePath());
+				Element artifactItemElement = new Element("artifactItem", groupIdElement, artifactIdElement,
+					versionElement, classifierElement, outputDirectoryElement);
+				Element artifactItemsItem = new Element("artifactItems", artifactItemElement);
+				Xpp3Dom configuration = MojoExecutor.configuration(artifactItemsItem);
 				ExecutionEnvironment environment = MojoExecutor.executionEnvironment(project, session,
 					pluginManager);
 				Plugin dependencyPlugin = MojoExecutor.plugin("org.apache.maven.plugins",
 					"maven-dependency-plugin", "2.8");
 				MojoExecutor.executeMojo(dependencyPlugin, "unpack", configuration, environment);
+			}
+			else
+			{
+				getLog().info("Using local binaries");
+				cmakeDir = new File(cmakeRootDir);
 			}
 
 			ProcessBuilder processBuilder = new ProcessBuilder(

--- a/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/TestMojo.java
+++ b/cmake-maven-plugin/src/main/java/com/googlecode/cmakemavenproject/TestMojo.java
@@ -100,15 +100,13 @@ public class TestMojo extends AbstractMojo
 	@Parameter(property = "cmake.root.dir", defaultValue = "/usr", required = false)
 	private String cmakeRootDir;
 
-	@Parameter(property = "cmake.child.dir", defaultValue = "bin/cmake", required = false)
-	private String cmakeChildDir;
-
 	@Parameter(property = "cmake.ctest.dir", defaultValue = "/", required = false)
 	private String ctestChildDir;
 
 	/**
 	 * Executes the CTest run.
 	 */
+	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException
 	{
 		Log log = getLog();

--- a/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
+++ b/cmake-maven-plugin/src/test/java/com/googlecode/cmakemavenproject/CMakeMojoIntegrationTest.java
@@ -49,8 +49,7 @@ public abstract class CMakeMojoIntegrationTest
 	 * @throws IOException           If there is a problem with configuration.
 	 * @throws VerificationException If there is a problem with verification.
 	 */
-	protected Verifier getVerifier(String testName) throws IOException,
-		VerificationException
+	protected Verifier getVerifier(String testName) throws IOException, VerificationException
 	{
 		Class<? extends CMakeMojoIntegrationTest> cls = getClass();
 		String name = testName.startsWith("/") ? testName : "/" + testName;
@@ -71,7 +70,7 @@ public abstract class CMakeMojoIntegrationTest
 			sysProperties.setProperty(DOWNLOAD_CMAKE, "false");
 		}
 		// Set the profile that's being used in the running of the tests
-		verifier.addCliOption(getActivatedProfile());
+		verifier.addCliOption("-P" + getActivatedProfile());
 
 		// use.mavenRepoLocal instructs forked tests to use the local repo
 		verProperties.setProperty("use.mavenRepoLocal", "true");
@@ -86,27 +85,7 @@ public abstract class CMakeMojoIntegrationTest
 	 */
 	private String getActivatedProfile() throws VerificationException
 	{
-		String classifier = System.getProperty(CMAKE_CLASSIFIER);
-
-		if (classifier.equals("linux64"))
-		{
-			return "-Plinux64,-linux32,-windows,-mac64";
-		}
-		else if (classifier.equals("linux32"))
-		{
-			return "-Plinux32,-linux64,-windows,-mac64";
-		}
-		else if (classifier.equals("windows"))
-		{
-			return "-Pwindows,-linux32,-linux64,-mac64";
-		}
-		else if (classifier.equals("mac64"))
-		{
-			return "-Pmac64,-windows,-linux32,-linux64";
-		}
-		else
-		{
-			throw new VerificationException("Unexpected test profile: " + classifier);
-		}
+		// For now, the activated profile just so happens to be equal to ${cmake.classifier}
+		return System.getProperty(CMAKE_CLASSIFIER);
 	}
 }

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -72,40 +72,20 @@
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-
-                                        <if>
-                                            <and>
-                                                <equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
-                                                <equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
-                                            </and>
-                                            <then>
-                                                <echo>Travis is priming dependenices, skipping the build.</echo>
-                                            </then>
-                                            <else>
-                                                <echo>Please activate one of the following profiles:</echo>
-                                                <echo>* windows-i386</echo>
-                                                <echo>* windows-amd64</echo>
-                                                <echo>* linux-i386</echo>
-                                                <echo>* linux-amd64</echo>
-                                                <echo>* linux-arm</echo>
-                                                <echo>* mac-amd64</echo>
-                                                <echo/>
-                                                <echo>For instance: mvn -Pwindows-amd64 install</echo>
-                                                <fail/>
-                                            </else>
-                                        </if>
+                                        <echo>Please activate one of the following profiles:</echo>
+                                        <echo>* windows-i386</echo>
+                                        <echo>* windows-amd64</echo>
+                                        <echo>* linux-i386</echo>
+                                        <echo>* linux-amd64</echo>
+                                        <echo>* linux-arm</echo>
+                                        <echo>* mac-amd64</echo>
+                                        <echo/>
+                                        <echo>For instance: mvn -Pwindows-amd64 install</echo>
+                                        <fail/>
                                     </target>
                                 </configuration>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ant-contrib</groupId>
-                                <artifactId>ant-contrib</artifactId>
-                                <version>20020829</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -80,6 +80,15 @@
                                         <echo>* mac-amd64</echo>
                                         <echo/>
                                         <echo>For instance: mvn -Pwindows-amd64 install</echo>
+
+                                        <!-- Avoid failing the build when Travis primes the build without a Maven profile -->
+                                        <condition property="is.travis">
+                                            <and>
+                                                <equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
+                                                <equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
+                                            </and>
+                                        </condition>
+                                        <fail unless="is.travis"/>
                                     </tasks>
                                 </configuration>
                             </execution>

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -71,12 +71,13 @@
                                 </goals>
                                 <configuration>
                                     <tasks>
-                                        <echo>please activate one of the following profiles:</echo>
-                                        <echo>* windows32</echo>
-                                        <echo>* windows64</echo>
-                                        <echo>* linux32</echo>
-                                        <echo>* linux64</echo>
-                                        <echo>* mac64</echo>
+                                        <echo>Please activate one of the following profiles:</echo>
+                                        <echo>* windows-i386</echo>
+                                        <echo>* windows-amd64</echo>
+                                        <echo>* linux-i386</echo>
+                                        <echo>* linux-amd64</echo>
+                                        <echo>* linux-arm</echo>
+                                        <echo>* mac-amd64</echo>
                                         <echo/>
                                         <echo>For instance: mvn -Pwindows64 install</echo>
                                         <fail/>
@@ -89,9 +90,9 @@
             </build>
         </profile>
         <profile>
-            <id>windows32</id>
+            <id>windows-i386</id>
             <properties>
-                <cmake.classifier>windows32</cmake.classifier>
+                <cmake.classifier>windows-i386</cmake.classifier>
                 <cmake.generator>Visual Studio 14 2015</cmake.generator>
                 <!-- with cygwin -->
                 <!-- <cmake.generator>Unix Makefiles</cmake.generator> -->
@@ -102,30 +103,39 @@
             </properties>
         </profile>
         <profile>
-            <id>windows64</id>
+            <id>windows-amd64</id>
             <properties>
-                <cmake.classifier>windows64</cmake.classifier>
+                <cmake.classifier>windows-amd64</cmake.classifier>
                 <cmake.generator>Visual Studio 14 2015</cmake.generator>
             </properties>
         </profile>
         <profile>
-            <id>linux32</id>
+            <id>linux-i386</id>
             <properties>
-                <cmake.classifier>linux32</cmake.classifier>
+                <cmake.classifier>linux-i386</cmake.classifier>
+                <download.cmake>false</download.cmake>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
-            <id>linux64</id>
+            <id>linux-amd64</id>
             <properties>
-                <cmake.classifier>linux64</cmake.classifier>
+                <cmake.classifier>linux-amd64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
-            <id>mac64</id>
+            <id>linux-arm</id>
             <properties>
-                <cmake.classifier>mac64</cmake.classifier>
+                <cmake.classifier>linux-arm</cmake.classifier>
+                <download.cmake>false</download.cmake>
+                <cmake.generator>Unix Makefiles</cmake.generator>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-amd64</id>
+            <properties>
+                <cmake.classifier>mac-amd64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <!-- with xcode -->
                 <!-- <cmake.generator>xcode</cmake.generator> -->

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,6 +26,7 @@
                             <sourcePath>${project.basedir}</sourcePath>
                             <targetPath>${project.build.directory}</targetPath>
                             <generator>${cmake.generator}</generator>
+                            <classifier>${cmake.classifier}</classifier>
                         </configuration>
                     </execution>
                     <execution>
@@ -52,31 +53,35 @@
             </plugin>
         </plugins>
     </build>
-    <!--
-        OS profile activation is triggered by the system's operating system.
-        This can be overridden by substracting a profile on the command line.
-
-        For instance: mvn -Pwindows,-linux64 install
-
-        To accept the OS activated profile, just use: mvn install
-    -->
     <profiles>
         <profile>
-            <id>pick-a-profile</id>
+            <id>list-profiles</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-help-plugin</artifactId>
-                        <version>2.2</version>
+                        <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
-                                <goals>
-                                    <goal>all-profiles</goal>
-                                </goals>
                                 <phase>validate</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
+                                        <echo>please activate one of the following profiles:</echo>
+                                        <echo>* windows32</echo>
+                                        <echo>* windows64</echo>
+                                        <echo>* linux32</echo>
+                                        <echo>* linux64</echo>
+                                        <echo>* mac64</echo>
+                                        <echo/>
+                                        <echo>For instance: mvn -Pwindows64 install</echo>
+                                        <fail/>
+                                    </tasks>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -84,13 +89,9 @@
             </build>
         </profile>
         <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
+            <id>windows32</id>
             <properties>
+                <cmake.classifier>windows32</cmake.classifier>
                 <cmake.generator>Visual Studio 14 2015</cmake.generator>
                 <!-- with cygwin -->
                 <!-- <cmake.generator>Unix Makefiles</cmake.generator> -->
@@ -101,38 +102,30 @@
             </properties>
         </profile>
         <profile>
-            <id>linux32</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <arch>i386</arch>
-                </os>
-            </activation>
+            <id>windows64</id>
             <properties>
+                <cmake.classifier>windows64</cmake.classifier>
+                <cmake.generator>Visual Studio 14 2015</cmake.generator>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux32</id>
+            <properties>
+                <cmake.classifier>linux32</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
             <id>linux64</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <arch>!i386</arch>
-                </os>
-            </activation>
             <properties>
+                <cmake.classifier>linux64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
             <id>mac64</id>
-            <activation>
-                <os>
-                    <name>Mac OS X</name>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
             <properties>
+                <cmake.classifier>mac64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <!-- with xcode -->
                 <!-- <cmake.generator>xcode</cmake.generator> -->
@@ -140,7 +133,7 @@
         </profile>
         <!--
           Other cmake.generators
-          http://www.cmake.org/cmake/help/v2.8.8/cmake.html#section_Generators
+          https://cmake.org/cmake/help/v3.7/manual/cmake-generators.7.html
         -->
     </profiles>
 </project>

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -79,8 +79,7 @@
                                         <echo>* linux-arm</echo>
                                         <echo>* mac-amd64</echo>
                                         <echo/>
-                                        <echo>For instance: mvn -Pwindows64 install</echo>
-                                        <fail/>
+                                        <echo>For instance: mvn -Pwindows-amd64 install</echo>
                                     </tasks>
                                 </configuration>
                             </execution>

--- a/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/dashboard-test/pom.xml
@@ -63,6 +63,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <phase>validate</phase>
@@ -70,29 +71,41 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
-                                        <echo>Please activate one of the following profiles:</echo>
-                                        <echo>* windows-i386</echo>
-                                        <echo>* windows-amd64</echo>
-                                        <echo>* linux-i386</echo>
-                                        <echo>* linux-amd64</echo>
-                                        <echo>* linux-arm</echo>
-                                        <echo>* mac-amd64</echo>
-                                        <echo/>
-                                        <echo>For instance: mvn -Pwindows-amd64 install</echo>
+                                    <target>
+                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
 
-                                        <!-- Avoid failing the build when Travis primes the build without a Maven profile -->
-                                        <condition property="is.travis">
+                                        <if>
                                             <and>
                                                 <equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
                                                 <equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
                                             </and>
-                                        </condition>
-                                        <fail unless="is.travis"/>
-                                    </tasks>
+                                            <then>
+                                                <echo>Travis is priming dependenices, skipping the build.</echo>
+                                            </then>
+                                            <else>
+                                                <echo>Please activate one of the following profiles:</echo>
+                                                <echo>* windows-i386</echo>
+                                                <echo>* windows-amd64</echo>
+                                                <echo>* linux-i386</echo>
+                                                <echo>* linux-amd64</echo>
+                                                <echo>* linux-arm</echo>
+                                                <echo>* mac-amd64</echo>
+                                                <echo/>
+                                                <echo>For instance: mvn -Pwindows-amd64 install</echo>
+                                                <fail/>
+                                            </else>
+                                        </if>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>ant-contrib</groupId>
+                                <artifactId>ant-contrib</artifactId>
+                                <version>20020829</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -71,12 +71,13 @@
                                 </goals>
                                 <configuration>
                                     <tasks>
-                                        <echo>please activate one of the following profiles:</echo>
-                                        <echo>* windows32</echo>
-                                        <echo>* windows64</echo>
-                                        <echo>* linux32</echo>
-                                        <echo>* linux64</echo>
-                                        <echo>* mac64</echo>
+                                        <echo>Please activate one of the following profiles:</echo>
+                                        <echo>* windows-i386</echo>
+                                        <echo>* windows-amd64</echo>
+                                        <echo>* linux-i386</echo>
+                                        <echo>* linux-amd64</echo>
+                                        <echo>* linux-arm</echo>
+                                        <echo>* mac-amd64</echo>
                                         <echo/>
                                         <echo>For instance: mvn -Pwindows64 install</echo>
                                         <fail/>
@@ -89,9 +90,9 @@
             </build>
         </profile>
         <profile>
-            <id>windows32</id>
+            <id>windows-i386</id>
             <properties>
-                <cmake.classifier>windows32</cmake.classifier>
+                <cmake.classifier>windows-i386</cmake.classifier>
                 <cmake.generator>Visual Studio 14 2015</cmake.generator>
                 <!-- with cygwin -->
                 <!-- <cmake.generator>Unix Makefiles</cmake.generator> -->
@@ -102,30 +103,39 @@
             </properties>
         </profile>
         <profile>
-            <id>windows64</id>
+            <id>windows-amd64</id>
             <properties>
-                <cmake.classifier>windows64</cmake.classifier>
+                <cmake.classifier>windows-amd64</cmake.classifier>
                 <cmake.generator>Visual Studio 14 2015</cmake.generator>
             </properties>
         </profile>
         <profile>
-            <id>linux32</id>
+            <id>linux-i386</id>
             <properties>
-                <cmake.classifier>linux32</cmake.classifier>
+                <cmake.classifier>linux-i386</cmake.classifier>
+                <download.cmake>false</download.cmake>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
-            <id>linux64</id>
+            <id>linux-amd64</id>
             <properties>
-                <cmake.classifier>linux64</cmake.classifier>
+                <cmake.classifier>linux-amd64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
-            <id>mac64</id>
+            <id>linux-arm</id>
             <properties>
-                <cmake.classifier>mac64</cmake.classifier>
+                <cmake.classifier>linux-arm</cmake.classifier>
+                <download.cmake>false</download.cmake>
+                <cmake.generator>Unix Makefiles</cmake.generator>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-amd64</id>
+            <properties>
+                <cmake.classifier>mac-amd64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <!-- with xcode -->
                 <!-- <cmake.generator>xcode</cmake.generator> -->

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,6 +26,7 @@
                             <sourcePath>${project.basedir}</sourcePath>
                             <targetPath>${project.build.directory}</targetPath>
                             <generator>${cmake.generator}</generator>
+                            <classifier>${cmake.classifier}</classifier>
                         </configuration>
                     </execution>
                     <execution>
@@ -52,31 +53,35 @@
             </plugin>
         </plugins>
     </build>
-    <!--
-        OS profile activation is triggered by the system's operating system.
-        This can be overridden by substracting a profile on the command line.
-
-        For instance: mvn -Pwindows,-linux64 install
-
-        To accept the OS activated profile, just use: mvn install
-    -->
     <profiles>
         <profile>
-            <id>pick-a-profile</id>
+            <id>list-profiles</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-help-plugin</artifactId>
-                        <version>2.2</version>
+                        <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
-                                <goals>
-                                    <goal>all-profiles</goal>
-                                </goals>
                                 <phase>validate</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
+                                        <echo>please activate one of the following profiles:</echo>
+                                        <echo>* windows32</echo>
+                                        <echo>* windows64</echo>
+                                        <echo>* linux32</echo>
+                                        <echo>* linux64</echo>
+                                        <echo>* mac64</echo>
+                                        <echo/>
+                                        <echo>For instance: mvn -Pwindows64 install</echo>
+                                        <fail/>
+                                    </tasks>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -84,13 +89,9 @@
             </build>
         </profile>
         <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
+            <id>windows32</id>
             <properties>
+                <cmake.classifier>windows32</cmake.classifier>
                 <cmake.generator>Visual Studio 14 2015</cmake.generator>
                 <!-- with cygwin -->
                 <!-- <cmake.generator>Unix Makefiles</cmake.generator> -->
@@ -101,38 +102,30 @@
             </properties>
         </profile>
         <profile>
-            <id>linux32</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <arch>i386</arch>
-                </os>
-            </activation>
+            <id>windows64</id>
             <properties>
+                <cmake.classifier>windows64</cmake.classifier>
+                <cmake.generator>Visual Studio 14 2015</cmake.generator>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux32</id>
+            <properties>
+                <cmake.classifier>linux32</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
             <id>linux64</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <arch>!i386</arch>
-                </os>
-            </activation>
             <properties>
+                <cmake.classifier>linux64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
             </properties>
         </profile>
         <profile>
             <id>mac64</id>
-            <activation>
-                <os>
-                    <name>Mac OS X</name>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
             <properties>
+                <cmake.classifier>mac64</cmake.classifier>
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <!-- with xcode -->
                 <!-- <cmake.generator>xcode</cmake.generator> -->
@@ -140,7 +133,7 @@
         </profile>
         <!--
           Other cmake.generators
-          http://www.cmake.org/cmake/help/v2.8.8/cmake.html#section_Generators
+          https://cmake.org/cmake/help/v3.7/manual/cmake-generators.7.html
         -->
     </profiles>
 </project>

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -72,41 +72,20 @@
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-
-                                        <!-- Avoid failing the build when Travis primes the build without a Maven profile -->
-                                        <if>
-                                            <and>
-                                                <equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
-                                                <equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
-                                            </and>
-                                            <then>
-                                                <echo>Travis is priming dependenices, skipping the build.</echo>
-                                            </then>
-                                            <else>
-                                                <echo>Please activate one of the following profiles:</echo>
-                                                <echo>* windows-i386</echo>
-                                                <echo>* windows-amd64</echo>
-                                                <echo>* linux-i386</echo>
-                                                <echo>* linux-amd64</echo>
-                                                <echo>* linux-arm</echo>
-                                                <echo>* mac-amd64</echo>
-                                                <echo/>
-                                                <echo>For instance: mvn -Pwindows-amd64 install</echo>
-                                                <fail/>
-                                            </else>
-                                        </if>
+                                        <echo>Please activate one of the following profiles:</echo>
+                                        <echo>* windows-i386</echo>
+                                        <echo>* windows-amd64</echo>
+                                        <echo>* linux-i386</echo>
+                                        <echo>* linux-amd64</echo>
+                                        <echo>* linux-arm</echo>
+                                        <echo>* mac-amd64</echo>
+                                        <echo/>
+                                        <echo>For instance: mvn -Pwindows-amd64 install</echo>
+                                        <fail/>
                                     </target>
                                 </configuration>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ant-contrib</groupId>
-                                <artifactId>ant-contrib</artifactId>
-                                <version>20020829</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -79,8 +79,7 @@
                                         <echo>* linux-arm</echo>
                                         <echo>* mac-amd64</echo>
                                         <echo/>
-                                        <echo>For instance: mvn -Pwindows64 install</echo>
-                                        <fail/>
+                                        <echo>For instance: mvn -Pwindows-amd64 install</echo>
                                     </tasks>
                                 </configuration>
                             </execution>

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -80,6 +80,15 @@
                                         <echo>* mac-amd64</echo>
                                         <echo/>
                                         <echo>For instance: mvn -Pwindows-amd64 install</echo>
+                                        
+                                        <!-- Avoid failing the build when Travis primes the build without a Maven profile -->
+                                        <condition property="is.travis">
+                                            <and>
+                                                <equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
+                                                <equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
+                                            </and>
+                                        </condition>
+                                        <fail unless="is.travis"/>
                                     </tasks>
                                 </configuration>
                             </execution>

--- a/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
+++ b/cmake-maven-plugin/src/test/resources/hello-world-test/pom.xml
@@ -63,6 +63,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <phase>validate</phase>
@@ -70,29 +71,42 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
-                                        <echo>Please activate one of the following profiles:</echo>
-                                        <echo>* windows-i386</echo>
-                                        <echo>* windows-amd64</echo>
-                                        <echo>* linux-i386</echo>
-                                        <echo>* linux-amd64</echo>
-                                        <echo>* linux-arm</echo>
-                                        <echo>* mac-amd64</echo>
-                                        <echo/>
-                                        <echo>For instance: mvn -Pwindows-amd64 install</echo>
-                                        
+                                    <target>
+                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
+
                                         <!-- Avoid failing the build when Travis primes the build without a Maven profile -->
-                                        <condition property="is.travis">
+                                        <if>
                                             <and>
                                                 <equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
                                                 <equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
                                             </and>
-                                        </condition>
-                                        <fail unless="is.travis"/>
-                                    </tasks>
+                                            <then>
+                                                <echo>Travis is priming dependenices, skipping the build.</echo>
+                                            </then>
+                                            <else>
+                                                <echo>Please activate one of the following profiles:</echo>
+                                                <echo>* windows-i386</echo>
+                                                <echo>* windows-amd64</echo>
+                                                <echo>* linux-i386</echo>
+                                                <echo>* linux-amd64</echo>
+                                                <echo>* linux-arm</echo>
+                                                <echo>* mac-amd64</echo>
+                                                <echo/>
+                                                <echo>For instance: mvn -Pwindows-amd64 install</echo>
+                                                <fail/>
+                                            </else>
+                                        </if>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>ant-contrib</groupId>
+                                <artifactId>ant-contrib</artifactId>
+                                <version>20020829</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -133,41 +133,20 @@
 								</goals>
 								<configuration>
 									<target>
-										<taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-
-										<!-- Avoid failing the build when Travis primes the build without a Maven profile -->
-										<if>
-											<and>
-												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
-												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
-											</and>
-											<then>
-												<echo>Travis is priming dependenices, skipping the build.</echo>
-											</then>
-											<else>
-												<echo>Please activate one of the following profiles:</echo>
-												<echo>* windows-i386</echo>
-												<echo>* windows-amd64</echo>
-												<echo>* linux-i386</echo>
-												<echo>* linux-amd64</echo>
-												<echo>* linux-arm</echo>
-												<echo>* mac-amd64</echo>
-												<echo/>
-												<echo>For instance: mvn -Pwindows-amd64 install</echo>
-												<fail/>
-											</else>
-										</if>
+										<echo>Please activate one of the following profiles:</echo>
+										<echo>* windows-i386</echo>
+										<echo>* windows-amd64</echo>
+										<echo>* linux-i386</echo>
+										<echo>* linux-amd64</echo>
+										<echo>* linux-arm</echo>
+										<echo>* mac-amd64</echo>
+										<echo/>
+										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+										<fail/>
 									</target>
 								</configuration>
 							</execution>
 						</executions>
-						<dependencies>
-							<dependency>
-								<groupId>ant-contrib</groupId>
-								<artifactId>ant-contrib</artifactId>
-								<version>20020829</version>
-							</dependency>
-						</dependencies>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -133,12 +133,13 @@
 								</goals>
 								<configuration>
 									<tasks>
-										<echo>please activate one of the following profiles:</echo>
-										<echo>* windows32</echo>
-										<echo>* windows64</echo>
-										<echo>* linux32</echo>
-										<echo>* linux64</echo>
-										<echo>* mac64</echo>
+										<echo>Please activate one of the following profiles:</echo>
+										<echo>* windows-i386</echo>
+										<echo>* windows-amd64</echo>
+										<echo>* linux-i386</echo>
+										<echo>* linux-amd64</echo>
+										<echo>* linux-arm</echo>
+										<echo>* mac-amd64</echo>
 										<echo/>
 										<echo>For instance: mvn -Pwindows64 install</echo>
 										<fail/>
@@ -151,19 +152,22 @@
 			</build>
 		</profile>
 		<profile>
-			<id>windows32</id>
+			<id>windows-i386</id>
 		</profile>
 		<profile>
-			<id>windows64</id>
+			<id>windows-amd64</id>
 		</profile>
 		<profile>
-			<id>linux32</id>
+			<id>linux-i386</id>
 		</profile>
 		<profile>
-			<id>linux64</id>
+			<id>linux-amd64</id>
 		</profile>
 		<profile>
-			<id>mac64</id>
+			<id>linux-arm</id>
+		</profile>
+		<profile>
+			<id>mac-amd64</id>
 		</profile>
 		<profile>
 			<id>sonatype-oss-release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,7 @@
 										<echo>* linux-arm</echo>
 										<echo>* mac-amd64</echo>
 										<echo/>
-										<echo>For instance: mvn -Pwindows64 install</echo>
-										<fail/>
+										<echo>For instance: mvn -Pwindows-amd64 install</echo>
 									</tasks>
 								</configuration>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@
 	</build>
 	<modules>
 		<module>cmake-binaries-plugin</module>
-		<module>cmake-binaries</module>
 		<module>cmake-maven-plugin</module>
 	</modules>
 	<properties>
@@ -175,21 +174,33 @@
 		</profile>
 		<profile>
 			<id>windows-i386</id>
+			<modules>
+				<module>cmake-binaries</module>
+			</modules>
 		</profile>
 		<profile>
 			<id>windows-amd64</id>
+			<modules>
+				<module>cmake-binaries</module>
+			</modules>
 		</profile>
 		<profile>
 			<id>linux-i386</id>
 		</profile>
 		<profile>
 			<id>linux-amd64</id>
+			<modules>
+				<module>cmake-binaries</module>
+			</modules>
 		</profile>
 		<profile>
 			<id>linux-arm</id>
 		</profile>
 		<profile>
 			<id>mac-amd64</id>
+			<modules>
+				<module>cmake-binaries</module>
+			</modules>
 		</profile>
 		<profile>
 			<id>sonatype-oss-release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.googlecode.cmake-maven-project</groupId>
 	<artifactId>cmake</artifactId>
-	<version>3.6.2-b1-SNAPSHOT</version>
+	<version>3.7.0-b1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>CMake</name>
 	<description>Builds native code using CMake makefile generator</description>
@@ -115,96 +115,80 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<arguments />
 	</properties>
-	<!--
-		OS profile activation is triggered by the system's operating system.
-		This can be overridden by substracting a profile on the command line.
-
-		For instance: mvn -Pwindows,-linux64 install
-
-		To accept the OS activated profile, just use: mvn install
-    -->
-    <profiles>
-        <profile>
-            <id>pick-a-profile</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-help-plugin</artifactId>
-                        <version>2.2</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>all-profiles</goal>
-                                </goals>
-                                <phase>validate</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-        </profile>
-        <profile>
-            <id>linux32</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <arch>i386</arch>
-                </os>
-            </activation>
-        </profile>
-        <profile>
-            <id>linux64</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <arch>!i386</arch>
-                </os>
-            </activation>
-        </profile>
-        <profile>
-            <id>mac64</id>
-            <activation>
-                <os>
-                    <name>Mac OS X</name>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
-        </profile>
-        <profile>
-            <id>sonatype-oss-release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- See https://maven.apache.org/guides/mini/guide-encryption.html -->
-                                    <passphraseServerId>gpg.passphrase</passphraseServerId>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+	<profiles>
+		<profile>
+			<id>list-profiles</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>validate</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<tasks>
+										<echo>please activate one of the following profiles:</echo>
+										<echo>* windows32</echo>
+										<echo>* windows64</echo>
+										<echo>* linux32</echo>
+										<echo>* linux64</echo>
+										<echo>* mac64</echo>
+										<echo/>
+										<echo>For instance: mvn -Pwindows64 install</echo>
+										<fail/>
+									</tasks>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>windows32</id>
+		</profile>
+		<profile>
+			<id>windows64</id>
+		</profile>
+		<profile>
+			<id>linux32</id>
+		</profile>
+		<profile>
+			<id>linux64</id>
+		</profile>
+		<profile>
+			<id>mac64</id>
+		</profile>
+		<profile>
+			<id>sonatype-oss-release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<!-- See https://maven.apache.org/guides/mini/guide-encryption.html -->
+									<passphraseServerId>gpg.passphrase</passphraseServerId>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,15 @@
 										<echo>* mac-amd64</echo>
 										<echo/>
 										<echo>For instance: mvn -Pwindows-amd64 install</echo>
+										
+										<!-- Avoid failing the build when Travis primes the build without a Maven profile -->
+										<condition property="is.travis">
+											<and>
+												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
+												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
+											</and>
+										</condition>
+										<fail unless="is.travis"/>
 									</tasks>
 								</configuration>
 							</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.8</version>
 						<executions>
 							<execution>
 								<phase>validate</phase>
@@ -132,29 +133,42 @@
 									<goal>run</goal>
 								</goals>
 								<configuration>
-									<tasks>
-										<echo>Please activate one of the following profiles:</echo>
-										<echo>* windows-i386</echo>
-										<echo>* windows-amd64</echo>
-										<echo>* linux-i386</echo>
-										<echo>* linux-amd64</echo>
-										<echo>* linux-arm</echo>
-										<echo>* mac-amd64</echo>
-										<echo/>
-										<echo>For instance: mvn -Pwindows-amd64 install</echo>
-										
+									<target>
+										<taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
+
 										<!-- Avoid failing the build when Travis primes the build without a Maven profile -->
-										<condition property="is.travis">
+										<if>
 											<and>
 												<equals arg1="${skipTests}" arg2="true" casesensitive="false"/>
 												<equals arg1="${maven.javadoc.skip}" arg2="true" casesensitive="false"/>
 											</and>
-										</condition>
-										<fail unless="is.travis"/>
-									</tasks>
+											<then>
+												<echo>Travis is priming dependenices, skipping the build.</echo>
+											</then>
+											<else>
+												<echo>Please activate one of the following profiles:</echo>
+												<echo>* windows-i386</echo>
+												<echo>* windows-amd64</echo>
+												<echo>* linux-i386</echo>
+												<echo>* linux-amd64</echo>
+												<echo>* linux-arm</echo>
+												<echo>* mac-amd64</echo>
+												<echo/>
+												<echo>For instance: mvn -Pwindows-amd64 install</echo>
+												<fail/>
+											</else>
+										</if>
+									</target>
 								</configuration>
 							</execution>
 						</executions>
+						<dependencies>
+							<dependency>
+								<groupId>ant-contrib</groupId>
+								<artifactId>ant-contrib</artifactId>
+								<version>20020829</version>
+							</dependency>
+						</dependencies>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
This PR contains some changes:

1. Removed automatic profile activation (but added a nice error message if you forget to specify a profile).
2. Stopped downloading binaries for 32-bit Linux (not my idea, cmake.org no longer provides them).
3. Added 32-bit Linux and Raspberry Pi Maven profiles that run cmake from a local installation (no need to set `download.cmake=false` manually any more).