### PR TITLE
Allow running the plugin with Java 8

### DIFF
--- a/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
+++ b/cmake-binaries-plugin/src/main/java/com/googlecode/cmakemavenproject/GetBinariesMojo.java
@@ -295,7 +295,7 @@ public class GetBinariesMojo
 	private void copyDirectory(final Path source, final Path target) throws IOException
 	{
 		Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
-			new FileVisitor<>()
+			new FileVisitor<Path>()
 			{
 				@Override
 				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
@@ -468,7 +468,7 @@ public class GetBinariesMojo
 	private void normalizeDirectories(final Path source) throws IOException
 	{
 		final Path[] topDirectory = new Path[1];
-		Files.walkFileTree(source, new SimpleFileVisitor<>()
+		Files.walkFileTree(source, new SimpleFileVisitor<Path>()
 		{
 			@Override
 			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
@@ -484,7 +484,7 @@ public class GetBinariesMojo
 		if (topDirectory[0] == null)
 			throw new IOException("Could not find \"bin\" in: " + source);
 
-		Files.walkFileTree(source, new SimpleFileVisitor<>()
+		Files.walkFileTree(source, new SimpleFileVisitor<Path>()
 		{
 			@Override
 			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException
@@ -529,7 +529,7 @@ public class GetBinariesMojo
 		// BUG: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7148952
 		if (Files.notExists(path))
 			return;
-		Files.walkFileTree(path, new SimpleFileVisitor<>()
+		Files.walkFileTree(path, new SimpleFileVisitor<Path>()
 		{
 			@Override
 			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.version>3.6.0</maven.version>
-		<maven.compiler.release>11</maven.compiler.release>
+		<maven.compiler.release>8</maven.compiler.release>
 		<maven.core.version>3.8.4</maven.core.version>
 		<maven.plugin.annotations.version>3.6.2</maven.plugin.annotations.version>
 	</properties>


### PR DESCRIPTION
Updates the maven-compiler-plugin to use `--release 8` so javac
builds classes that are compatible to Java 8 and newer.

This helps people having a code base that still supports Java 8
to use recent versions of this plugin.