### PR TITLE
Add aarch64 linux.

### DIFF
--- a/cmake-common/src/main/java/com/googlecode/cmakemavenproject/OperatingSystem.java
+++ b/cmake-common/src/main/java/com/googlecode/cmakemavenproject/OperatingSystem.java
@@ -63,6 +63,8 @@ public final class OperatingSystem
 						return "linux-arm_32";
 					case X86_64:
 						return "linux-x86_64";
+					case ARM_64:
+						return "linux-aarch64";
 					default:
 						throw new UnsupportedOperationException("Unsupported architecture: " + architecture);
 				}
@@ -151,9 +153,15 @@ public final class OperatingSystem
 		switch (type)
 		{
 			case LINUX:
-				if (architecture == Architecture.X86_64)
-					return "linux-x86_64.tar.gz";
-				throw new UnsupportedOperationException("Unsupported architecture: " + architecture);
+				switch (architecture)
+				{
+					case X86_64:
+						return "linux-x86_64.tar.gz";
+					case ARM_64:
+						return "linux-aarch64.tar.gz";
+					default:
+						throw new UnsupportedOperationException("Unsupported architecture: " + architecture);
+				}
 			case MAC:
 				switch (architecture)
 				{

--- a/jenkins/cmake (release)/config.xml
+++ b/jenkins/cmake (release)/config.xml
@@ -163,7 +163,8 @@ try
                         // Deploy both Java and native artifacts
                         // Use the same GCC version as AWS. See top of this script for more information.
 
-                        sh script: &quot;&quot;&quot;sudo apt-get install build-essential -y
+                        sh script: &quot;&quot;&quot;sudo apt-get update
+                          sudo apt-get install build-essential -y
                           mvn --batch-mode -e -V -U -Dsurefire.useFile=false install
                           mvn --batch-mode -e -V -U -Dsurefire.useFile=false -DstagingProfileId=${stagingProfileId} -DstagingRepositoryId=${stagingRepositoryId} -Ddeploy -Dportable deploy&quot;&quot;&quot;
                         archiveArtifacts artifacts: &quot;**/target/*.jar&quot;, excludes: &quot;**/target/test-classes/**&quot;

--- a/jenkins/cmake (snapshot)/config.xml
+++ b/jenkins/cmake (snapshot)/config.xml
@@ -61,7 +61,8 @@ parallel linux:
             {
                 stage(&quot;Deploy (linux)&quot;)
                 {
-                    sh script: &quot;&quot;&quot;sudo apt-get install build-essential -y
+                    sh script: &quot;&quot;&quot;sudo apt-get update
+                        sudo apt-get install build-essential -y
                         mvn --batch-mode -V -e -U -Dsurefire.useFile=false -Ddeploy deploy&quot;&quot;&quot;
                     archiveArtifacts artifacts: &apos;**/target/*.jar&apos;, excludes: &apos;**/target/test-classes/**&apos;
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@
 										<echo>Please activate one of the following profiles:</echo>
 										<echo>* windows-x86_64</echo>
 										<echo>* linux-x86_64</echo>
+										<echo>* linux-aarch64</echo>
 										<echo>* linux-arm_32</echo>
 										<echo>* mac-x86_64</echo>
 										<echo>* mac-aarch64</echo>
@@ -297,6 +298,21 @@
 			</activation>
 			<properties>
 				<platform>linux-x86_64</platform>
+			</properties>
+			<modules>
+				<module>cmake-binaries</module>
+			</modules>
+		</profile>
+		<profile>
+			<id>linux-aarch64</id>
+			<activation>
+				<os>
+                                        <family>linux</family>
+                                        <arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<platform>linux-aarch64</platform>
 			</properties>
 			<modules>
 				<module>cmake-binaries</module>


### PR DESCRIPTION
This adds aarch64 linux. A few notes:

1. It appears you have a catch22 in your build. You need to deploy the binary artifacts before you can fully build (that is, run the tests) for the dependency `cmake-maven-plugin`.  I hacked the tests by changing the cmake-maven-plugin/test/resources/settings.xml file to point to my main repository and the tests passed (and obviously put it back before committing the PR).

2. This seems wrong, though I didn't change anything there: https://github.com/cmake-maven-project/cmake-maven-project/blob/master/cmake-common/src/main/java/com/googlecode/cmakemavenproject/OperatingSystem.java#L62 . The X86_32 results in an arm binary? 